### PR TITLE
Potential fix for unittest RDBBtree.SindexInterruptionViaDrop failure

### DIFF
--- a/src/rdb_protocol/btree_store.cc
+++ b/src/rdb_protocol/btree_store.cc
@@ -854,10 +854,8 @@ void store_t::drop_sindex(uuid_u sindex_id) THROWS_NOTHING {
     if (!found) {
         // The index got dropped by someone else. That's ok, there's nothing left for us
         // to do.
-
         sindex_block.reset_buf_lock();
         txn->commit();
-
         return;
     }
 

--- a/src/rdb_protocol/btree_store.cc
+++ b/src/rdb_protocol/btree_store.cc
@@ -746,6 +746,8 @@ void store_t::clear_sindex_data(
         if (!found) {
             // The index got dropped by someone else. That's ok, there's nothing left
             // to do for us.
+            sindex_block.reset_buf_lock();
+            txn->commit();
             return;
         }
 
@@ -852,6 +854,10 @@ void store_t::drop_sindex(uuid_u sindex_id) THROWS_NOTHING {
     if (!found) {
         // The index got dropped by someone else. That's ok, there's nothing left for us
         // to do.
+
+        sindex_block.reset_buf_lock();
+        txn->commit();
+
         return;
     }
 


### PR DESCRIPTION
- [x] I have read and agreed to the RethinkDB Contributor License Agreement http://rethinkdb.com/community/cla/

### Description
RDBBtree.SindexInterruptionViaDrop had been failing at the guarantee in `txn_t::~txn_t`.

I managed to track the issue down to `store_t::clear_sindex_data` not committing the transaction before returning.  This patch adds transaction commit to `store_t::clear_sindex_data` and `store_t::drop_sindex`.

While this does fix the unit test failing, could someone with a more complete understanding of the code make sure this is right and does no suffer from any bad side affects which I'm unaware of thanks.